### PR TITLE
add go.mod for working build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module sandfly-processdecloak
+
+go 1.19


### PR DESCRIPTION
Hello guys, I tried to build this utility but due to missing `go.mod` this error was returned: 

`package sandfly-processdecloak/processutils is not in GOROOT`