### PR TITLE
Use os.ReadDir() instead of deprecated ioutil.ReadDir()

### DIFF
--- a/processutils/processutils.go
+++ b/processutils/processutils.go
@@ -35,7 +35,6 @@ Author: Sandfly Security @SandflySecurity
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -126,10 +125,27 @@ func IsPidHidden(pid int, raceVerify bool) (pidHidden bool, err error) {
 			//
 			// Only do this check if the above check didn't return hidden already.
 			if pidHidden == false {
-				files, err := ioutil.ReadDir("/proc")
+				files, err := os.ReadDir("/proc")
 				if err != nil {
 					return pidHidden, fmt.Errorf("there was an error reading the /proc directory to find hidden PIDS: %v", err)
 				}
+				/*
+					infos := make([]fs.FileInfo, 0, len(entries))
+					for _, entry := range entries {
+						info, err := entry.Info()
+						if err != nil {
+							return
+						}
+						infos = append(infos, info)
+					}
+				*/
+
+				/*
+					files, err := ioutil.ReadDir("/proc")
+					if err != nil {
+						return pidHidden, fmt.Errorf("there was an error reading the /proc directory to find hidden PIDS: %v", err)
+					}
+				*/
 				pidHidden = true
 				for _, f := range files {
 					pidToCheck, _ := strconv.Atoi(f.Name())

--- a/processutils/processutils.go
+++ b/processutils/processutils.go
@@ -35,6 +35,7 @@ Author: Sandfly Security @SandflySecurity
 import (
 	"bufio"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"strconv"
@@ -125,20 +126,19 @@ func IsPidHidden(pid int, raceVerify bool) (pidHidden bool, err error) {
 			//
 			// Only do this check if the above check didn't return hidden already.
 			if pidHidden == false {
-				files, err := os.ReadDir("/proc")
+				entries, err := os.ReadDir("/proc")
 				if err != nil {
 					return pidHidden, fmt.Errorf("there was an error reading the /proc directory to find hidden PIDS: %v", err)
 				}
-				/*
-					infos := make([]fs.FileInfo, 0, len(entries))
-					for _, entry := range entries {
-						info, err := entry.Info()
-						if err != nil {
-							return
-						}
-						infos = append(infos, info)
+
+				files := make([]fs.FileInfo, 0, len(entries))
+				for _, entry := range entries {
+					info, err := entry.Info()
+					if err != nil {
+						return
 					}
-				*/
+					files = append(files, info)
+				}
 
 				/*
 					files, err := ioutil.ReadDir("/proc")
@@ -146,6 +146,7 @@ func IsPidHidden(pid int, raceVerify bool) (pidHidden bool, err error) {
 						return pidHidden, fmt.Errorf("there was an error reading the /proc directory to find hidden PIDS: %v", err)
 					}
 				*/
+
 				pidHidden = true
 				for _, f := range files {
 					pidToCheck, _ := strconv.Atoi(f.Name())

--- a/sandfly-processdecloak.go
+++ b/sandfly-processdecloak.go
@@ -58,15 +58,16 @@ func main() {
 		log.Fatalf("error analyzing PIDs: %#v\n", err)
 	}
 
-	if len(hiddenPIDs) > 0 {
-		for x := range hiddenPIDs {
-			status, err := processutils.Status(hiddenPIDs[x])
-			if err != nil {
-				log.Fatalf("error reporting status on hidden PID %d : %#v", hiddenPIDs[x], err)
-			}
-			fmt.Printf("Found hidden PID: %d with name: %s\n", hiddenPIDs[x], status.Name)
-		}
-	} else {
+	if len(hiddenPIDs) == 0 {
 		fmt.Printf("No hidden PIDs found.\n")
+	} else {
+		for _, pid := range hiddenPIDs {
+			status, err := processutils.Status(pid)
+			if err != nil {
+				log.Fatalf("error reporting status on hidden PID %d : %#v", pid, err)
+			}
+			fmt.Printf("Found hidden PID: %d with name: %s\n", pid, status.Name)
+		}
 	}
+
 }


### PR DESCRIPTION
Hello! 

I saw that the `io/ioutil` library is still used in the main process ([processutils/processutils.go](https://github.com/sandflysecurity/sandfly-processdecloak/blob/master/processutils/processutils.go#L129)), which is deprecated (Go v1.16). 

So I tried to replace it as recommended in the official Go documentation: [https://pkg.go.dev/io/ioutil#ReadDir](https://pkg.go.dev/io/ioutil#ReadDir)